### PR TITLE
Make assembleProgram more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,14 @@ export default batchPrograms(
 )
 ```
 
-### `assembleProgram({data, view, logic, deps, options}): RajProgram`
-The `assembleProgram` function takes three functions: `data(deps, options)`, `view(model, dispatch)`, and `logic(data(deps, options), options)`.
-The `deps`, `options`, and return value of `data` can be anything that makes sense to the program.
+### `assembleProgram({data, view, logic, dataOptions, viewOptions, logicOptions}): RajProgram`
+The `assembleProgram` function takes three functions:
+
+- `data(dataOptions)`
+- `view(model, dispatch, viewOptions)`
+- `logic(data(dataOptions), logicOptions)`
+
+The `dataOptions`, `viewOptions`, `logicOptions`, and return value of `data` can be anything that makes sense to the program.
 This will return a program where `logic()` would return an object containing `{init, update, done, ...}` properties that merge in with `view`.
 
 This function is good for separating the concerns common to most programs: data-fetching, views, and business logic.

--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,22 @@ function batchPrograms (programs, containerView) {
   return {init, update, view, done}
 }
 
-function assembleProgram ({data, view, logic, deps, options}) {
-  return Object.assign({view}, logic(data(deps, options), options))
+function assembleProgram ({
+  data,
+  dataOptions,
+  logic,
+  logicOptions,
+  view,
+  viewOptions
+}) {
+  return Object.assign(
+    {
+      view (model, dispatch) {
+        return view(model, dispatch, viewOptions)
+      }
+    },
+    logic(data(dataOptions), logicOptions)
+  )
 }
 
 exports.mapEffect = mapEffect

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,8 @@ import {
   mapEffect,
   batchEffects,
   mapProgram,
-  batchPrograms
+  batchPrograms,
+  assembleProgram
 } from '../src'
 
 test('mapEffect() transforms any dispatched messages', t => {
@@ -154,4 +155,41 @@ test('batchPrograms() should return a done which calls sub program dones', t => 
 
   const [state] = program.init
   program.done(state)
+})
+
+test('assembleProgram() should return an assembled program', t => {
+  t.plan(5)
+
+  const dataOptions = {}
+  const logicOptions = {}
+  const viewOptions = {}
+  const dataResult = {}
+
+  function data (options) {
+    t.is(options, dataOptions)
+    return dataResult
+  }
+
+  function logic (data, options) {
+    t.is(data, dataResult)
+    t.is(options, logicOptions)
+
+    return {foo: 'bar'}
+  }
+
+  function view (model, dispatch, options) {
+    t.is(options, viewOptions)
+  }
+
+  const program = assembleProgram({
+    data,
+    dataOptions,
+    view,
+    viewOptions,
+    logic,
+    logicOptions
+  })
+
+  t.is(program.foo, 'bar')
+  program.view()
 })


### PR DESCRIPTION
The initial `assembleProgram` used keys `deps` and `options` but those names are weird. Now we have a consistent naming pattern and now `view` gets its own options too.

- `data` / `dataOptions`
- `view` / `viewOptions`
- `logic` / `logicOptions`

This is based on my experience weaving programs with dependencies together. Specifically here `viewOptions` is useful for passing sub-program functions to the parent view.