### PR TITLE
Remove tagmeme dependency and remove cruft

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ The `view()` `state` is the child program's state and `dispatch` is the parent's
 
 > `batchPrograms(programs: Array<RajProgram>, containerView: function): RajProgram`
 
-The `batchPrograms` function takes an array of programs and a `containerView` and create a new program which manages those child programs.
+The `batchPrograms` function takes an array of `programs` and a `containerView` function and creates a new program which manages those child programs.
 If any item in the `programs` array is not a program, an error will throw.
 If `containerView` is not a function, an error will throw.
 
-The containerView receives an array of function, each respective to the programs in the `programs` array that when called return a view to nest somewhere in the parent view.
+The `containerView` receives an array of functions which return views for each respective program.
 
 #### Example
 We have a main view and a sidebar view that we would like to display at the same time. We are using React as our view layer so we are using JSX to describe our HTML. We use the `batchPrograms` to unite the two programs in the same app view.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "url": "https://github.com/andrejewski/raj-compose/issues"
   },
   "dependencies": {
-    "invariant": "^2.2.2",
-    "tagmeme": "0.0.7"
+    "invariant": "^2.2.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/test/index.js
+++ b/test/index.js
@@ -128,9 +128,7 @@ test('mapProgram() should return a done if the original program does', t => {
   t.is(notDoneProgram.done, undefined)
 })
 
-test('batchPrograms() should return a done which calls sub program dones', t => {
-  t.plan(2)
-
+test('batchPrograms() program.done should call sub program done functions', t => {
   const subProgramWithDone = {
     init: ['foo'],
     update () {},
@@ -150,8 +148,6 @@ test('batchPrograms() should return a done which calls sub program dones', t => 
     subProgramWithDone,
     subProgramWithoutDone
   ], () => {})
-
-  t.is(typeof program.done, 'function')
 
   const [state] = program.init
   program.done(state)


### PR DESCRIPTION
- Drop Tagmeme dependency
- Get rid of old "done returns an effect" handling
- Clean up and make `batchPrograms` efficient
- Remove transpilation bloat

Tagmeme is still recommended in general but is not required in `raj-compose`. There was not any noticeable performance problems with `batchPrograms`, but removing Tagmeme made `update` in particular faster, which is to be expected.

Usage of `[a, b] = arr` and other niceties have been removed to cut out the transpilation bloat in the published module. This bloat was pretty close to the size of `raj-compose` itself.